### PR TITLE
[OPS-01] Automated DAG agent runner

### DIFF
--- a/.agents/skills/clear-dag-runner/SKILL.md
+++ b/.agents/skills/clear-dag-runner/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: clear-dag-runner
+description: Runs CLEAR build work from the live GitHub dependency graph. Use when Eric asks Codex to run the DAG, automate the build, take ready issues, work unattended, or continue the CLEAR rebuild.
+---
+
+# CLEAR DAG runner
+
+Read `docs/process/DAG_RUNNER.md` and `docs/process/HUMAN_GATES.md` completely, then follow them.
+
+Run `python3 scripts/dag-ready.py` before choosing work. Read the selected issue and its comments.
+Use single-issue mode unless Eric explicitly asks to run for a while, run unattended, or use runway
+mode. In runway mode, continue across unclaimed ready issues one at a time without waiting between
+them, but never work a blocked issue, merge without the approved policy, or route around a human gate.

--- a/.claude/skills/clear-dag-runner/SKILL.md
+++ b/.claude/skills/clear-dag-runner/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: clear-dag-runner
+description: Runs CLEAR build work from the live GitHub dependency graph. Use when Eric asks Claude Code to run the DAG, automate the build, take ready issues, work unattended, or continue the CLEAR rebuild.
+---
+
+# CLEAR DAG runner
+
+Read `docs/process/DAG_RUNNER.md` and `docs/process/HUMAN_GATES.md` completely, then follow them.
+
+Run `python3 scripts/dag-ready.py` before choosing work. Read the selected issue and its comments.
+Use single-issue mode unless Eric explicitly asks to run for a while, run unattended, or use runway
+mode. In runway mode, continue across unclaimed ready issues one at a time without waiting between
+them, but never work a blocked issue, merge without the approved policy, or route around a human gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ Before material work, read `docs/process/AGENT_PLAYBOOK.md` and `PROJECT_MAP.md`
 the GitHub ready queue; use one issue, one branch, and one pull request. Do not implement a blocked
 issue or silently widen an issue's scope.
 
+Run `python3 scripts/dag-ready.py` instead of choosing from the issue list manually. When the user
+asks to run the DAG, automate the build, work unattended, or continue the rebuild, use the project
+skill `clear-dag-runner` and its canonical loop in `docs/process/DAG_RUNNER.md`.
+
 ## Process journal
 
 For every material work session, maintain `docs/journal/YYYY-MM-DD.md` at meaningful checkpoints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,14 @@ background reading.
 Work comes from the ready queue, never from scrolling the issue list:
 
 ```sh
-gh issue list --search "is:open -is:blocked"
+python3 scripts/dag-ready.py
 ```
 
-An issue appears there exactly when everything it depends on has closed. Take one — lowest
-milestone first, then whichever unblocks the most (`docs/DAG.md` § *Highest leverage*).
+The command cross-checks GitHub's native ready search, excludes issues already in an open PR, and
+ranks what remains. Take its recommendation unless Eric named another available ready issue.
+
+When Eric asks to run the DAG, automate the build, work unattended, or run for a while, use the
+project skill `clear-dag-runner`. Its canonical loop is `docs/process/DAG_RUNNER.md`.
 
 **Never work an issue that is not in the ready queue.** If it looks ready but the queue
 disagrees, the graph is right — go read what it is blocked by.
@@ -26,8 +29,8 @@ disagrees, the graph is right — go read what it is blocked by.
 
 ## What to read, in this order
 
-1. **The issue body.** Its acceptance checklist is the definition of done — not a starting
-   point, not a suggestion.
+1. **The issue body and comments.** Its acceptance checklist is the definition of done; comments
+   can contain later owner decisions — neither is a suggestion.
 2. **Its `Spec:` references.** All under `docs/`. Nothing points outside this repo.
 3. **`PROJECT_MAP.md`** — how the codebase is arranged, so a new file lands where this
    project puts that kind of file.

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -12,6 +12,8 @@ This is the honest ENV-01 scaffold. Update it only when a directory boundary or 
 | `src/test/` | Shared test setup | adding test-only configuration or helpers |
 | `docs/` | Frozen baseline and deep specs | recording product/design/process knowledge, not runtime code |
 | `scripts/` | Repository automation | adding a deterministic local or CI maintenance command |
+| `.claude/skills/` | Claude Code project entry points | exposing a reusable workflow to Anthropic tooling |
+| `.agents/skills/` | Codex project entry points | exposing the same reusable workflow to Codex |
 
 Current flow is only `index.html → src/main.tsx → src/app/router.tsx`. Data and state boundaries are
 stubs until their DAG issues land. No backend client exists yet.

--- a/docs/journal/2026-08-29.md
+++ b/docs/journal/2026-08-29.md
@@ -158,6 +158,11 @@ longer unattended runs.
 - Runner unit tests: 4 passed. Frozen graph validation: 71 requirements, 136 edges. Application
   verification: ESLint passed; Vitest 1 file/2 tests passed; TypeScript and Vite production build
   passed with 25 modules transformed. `git diff --check` passed.
-- Next safe action: commit/push OPS-01 and open a PR that closes issue 73. After merge, invoking the
-  `clear-dag-runner` skill in runway mode can begin the available product queue; service-specific
+- Committed and pushed branch `ops-01-dag-runner`; opened mergeable PR 74 with `Closes #73`. GitHub
+  reports no automated checks because ENV-02 is still an available, unimplemented node.
+- Re-ran the live command after opening the PR: seven issues remained dependency-ready, OPS-01 was
+  correctly marked `PR #74`, six remained available, and DS-01 remained the recommendation. This
+  verifies duplicate-work suppression against a real closing-issue reference.
+- Next safe action: review and merge PR 74. Then synchronize `main`; invoking the
+  `clear-dag-runner` skill in runway mode can begin the available product queue. Service-specific
   issues pause only at the documented human gates.

--- a/docs/journal/2026-08-29.md
+++ b/docs/journal/2026-08-29.md
@@ -111,3 +111,53 @@ project startup, with the ready-queue constraint and the same process-journal re
 existing `.cursor/rules/process-journal.mdc` remains in place for compatible clients. CLEAR can now
 be worked with Anthropic tooling or Codex without relying on either tool to understand the other
 vendor's instruction-file convention.
+
+## Post-merge runway and catalog scope
+
+### Intended outcome
+
+After PR 72 merged, synchronize local `main`, preserve all reusable old exercise-catalog data while
+excluding user history, and make the live DAG directly operable by Anthropic tooling and Codex for
+longer unattended runs.
+
+### Repository and GitHub changes
+
+- Fast-forwarded local `main` to merged commit `35b938e`; the working copy matched `origin/main`
+  before new work began.
+- Created live follow-up issue 73, OPS-01, for the automation itself so process work does not widen a
+  product requirement. Connected it to closed ENV-01 and created branch `ops-01-dag-runner`.
+- Recorded Eric's catalog-only migration decision on DATA-02: keep all reusable exercise/reference
+  metadata; exclude auth users, profiles, locations, workouts, sessions, logs, and other history.
+
+### Catalog audit and corrected assumption
+
+- Audited the archived private repository `theycallme-eric/clear-app` without reading or copying any
+  secret values or user data.
+- The committed migrations insert 145 unique exercise IDs, then consolidate/remove variants to 140
+  final definitions. The final tag migration covers all 140; the muscle junction seed contains 488
+  rows; 13 secondary anchor mappings are explicit.
+- DATA-02 expects 173 exercises. The old repository is therefore a reproducible partial source, not
+  proof of live-database equivalence. The 33-row difference must be reconciled against the old live
+  Supabase catalog. The expected count was not silently changed.
+
+### Automation correction and implementation
+
+- A prior readiness check used `blockedBy.totalCount`; GitHub includes closed blockers in that total,
+  which makes newly released work appear blocked. The runner now cross-checks GitHub's native
+  `is:open -is:blocked` search and independently counts only dependency nodes whose state is OPEN.
+- Added a deterministic ready-queue command that ranks available work by milestone, open fan-out,
+  then critical-path membership and marks issues already attached to open PRs as in progress.
+- Added one canonical runner policy, a known-human-gates map, the catalog migration boundary, and
+  thin project skills for Claude Code and Codex. Runway mode may continue to another independent
+  ready issue when one issue reaches a gate; it does not auto-merge or bypass credentials.
+
+### Verification and next safe action
+
+- The live runner cross-check passed: seven ready issues (the six released product nodes plus
+  OPS-01), all available, with DS-01 recommended first by its 10 open dependents.
+- Runner unit tests: 4 passed. Frozen graph validation: 71 requirements, 136 edges. Application
+  verification: ESLint passed; Vitest 1 file/2 tests passed; TypeScript and Vite production build
+  passed with 25 modules transformed. `git diff --check` passed.
+- Next safe action: commit/push OPS-01 and open a PR that closes issue 73. After merge, invoking the
+  `clear-dag-runner` skill in runway mode can begin the available product queue; service-specific
+  issues pause only at the documented human gates.

--- a/docs/process/AGENT_PLAYBOOK.md
+++ b/docs/process/AGENT_PLAYBOOK.md
@@ -13,7 +13,7 @@ Companions: `docs/DAG.md` (the graph), `docs/requirements/REQUIREMENTS.md` (the 
 ## 1. The loop
 
 ```
-  gh issue list --search "is:open -is:blocked"     ← the ready queue IS the backlog
+  python3 scripts/dag-ready.py                      ← verified + ranked ready queue
               │
               ▼
   pick one  ──────►  read: issue body → its Spec refs → PROJECT_MAP → ATOMIC (if UI)
@@ -33,13 +33,18 @@ construction — an issue appears in it exactly when everything it depends on ha
 ## 2. Picking work
 
 ```sh
-gh issue list --search "is:open -is:blocked" --json number,title,labels,milestone
+python3 scripts/dag-ready.py
 ```
 
-At the start that returns exactly one issue: **ENV-01**. After it closes, six. After the
-next wave, thirteen. `docs/DAG.md` has the full shape.
+The frozen v0.7 graph started with exactly one issue, **ENV-01**, then released six after it closed.
+Post-baseline follow-up issues may add ready process work; the live command, not a number in this
+document, is authoritative. `docs/DAG.md` has the frozen product-graph shape.
 
-When several are ready, in order:
+The command cross-checks GitHub's native `is:open -is:blocked` result against dependency nodes with
+only **open** blockers counted. This matters because GitHub's raw blocker total also includes closed
+issues. It also marks a ready issue as in progress when an open PR closes it.
+
+When several are available, it ranks them in order:
 
 1. **Lower milestone first.** M0 before M1. The milestones are a real sequence, not a
    grouping — M1 assumes M0's foundation exists.
@@ -58,8 +63,9 @@ disagrees, the graph is right and the intuition is wrong — go read what it is 
 An agent that reads too much wastes context; one that reads too little invents things that
 already exist. The order is deliberate:
 
-1. **The issue body.** The acceptance checklist is the definition of done — not a
-   suggestion, not a starting point. It is copied verbatim from the requirement.
+1. **The issue body and comments.** The acceptance checklist is the definition of done — not a
+   suggestion or starting point. Comments can contain owner decisions made after the frozen
+   baseline, so reading the body alone is insufficient.
 2. **Its `Spec:` references.** Every spec lives in this workspace. Nothing points at the
    archived repo.
 3. **`PROJECT_MAP.md`** — how the codebase is currently arranged. Read before writing a

--- a/docs/process/CATALOG_MIGRATION_SCOPE.md
+++ b/docs/process/CATALOG_MIGRATION_SCOPE.md
@@ -1,0 +1,41 @@
+# Catalog migration scope
+
+Owner decision recorded 2026-08-29: the rebuild keeps reusable workout catalog/reference data from
+the old CLEAR database and starts user history fresh.
+
+## Include
+
+- exercise IDs and display names;
+- equipment options, defaults, and equipment-specific display names;
+- section eligibility and primary-lift eligibility;
+- coaching cues and regression/progression relationships, preserving valid nulls;
+- component movements and exercise roles;
+- muscle-group mappings and their primary/synergist/stabilizer roles;
+- pattern/anchor information required to produce the new pattern weights and prove taxonomy
+  equivalence.
+
+## Exclude
+
+- authentication users, profiles, locations, preferences, limitations, and onboarding state;
+- generated, saved, scheduled, or completed workouts and their sections/exercises;
+- set logs, block results, streaks, history, favorites, and other personal activity;
+- secrets, access tokens, private contact data, and service credentials.
+
+DATA-02's optional `--dev` mode creates new dev-only data. It must never copy an old user row.
+
+## Verified source status
+
+The archived private repository `theycallme-eric/clear-app` contains the old schema and seed history.
+Static audit of its migrations found:
+
+- 145 unique exercise IDs inserted before consolidation;
+- consolidation/removal produces 140 final exercise definitions;
+- all 140 final definitions receive `component_movements` and `exercise_role` tags;
+- 488 exercise-to-muscle-group rows are committed;
+- primary anchors are derived from the old pattern relationship and 13 secondary anchor mappings are
+  explicitly added.
+
+The live DATA-02 acceptance criterion expects 173 exercises. Therefore the committed old repository
+is a reproducible starting point, but not proof of the old live database's final contents. DATA-02
+must export/read the old live catalog, reconcile the 33-row difference, and commit a sanitized
+catalog-only artifact. It may not silently lower the expectation to 140 or export user tables.

--- a/docs/process/DAG_RUNNER.md
+++ b/docs/process/DAG_RUNNER.md
@@ -1,0 +1,66 @@
+# CLEAR DAG runner
+
+This is the canonical operating loop for a coding agent working CLEAR. Claude Code and Codex have
+thin project-local skills that point here so the behavior does not drift between tools.
+
+## Start
+
+1. Read `CLAUDE.md` or `AGENTS.md`, `PROJECT_MAP.md`, and this document.
+2. Confirm the working tree is clean. Preserve and report work you did not create.
+3. Synchronize safely: fetch, switch to `main`, and fast-forward only. Never reset or discard local
+   work to make synchronization succeed.
+4. Run `python3 scripts/dag-ready.py`. It cross-checks two live GitHub readiness signals, ranks the
+   queue, and excludes ready issues already tied to an open pull request.
+5. Take the recommendation unless the user named another **available ready** issue. If the command
+   refuses to recommend work, fix or report the graph/query problem; do not choose by intuition.
+
+## Load one issue
+
+1. Read the issue **and its comments**. Comments can contain owner decisions made after the frozen
+   requirements baseline.
+2. Read only the issue's `Spec:` references, then `PROJECT_MAP.md`.
+3. For any UI issue, also read `docs/specs/design/ATOMIC.md`; for a screen, read `docs/specs/IA.md`.
+4. Convert every acceptance box into a verification checklist before editing.
+5. Create a branch named from the issue ID and intent. One issue gets one branch and one pull request.
+
+## Build and verify
+
+- Implement only the selected issue. If another issue's output is required, treat that as a graph
+  defect: comment on the issue, stop that issue, and select another available ready issue.
+- Test at the narrowest useful level while working, then run every repository gate relevant to the
+  changed surface. Record exact commands and results in the process journal.
+- Update `PROJECT_MAP.md` when a directory boundary or data flow changes.
+- Update `docs/journal/YYYY-MM-DD.md` at meaningful checkpoints and before handoff. Include failures,
+  causes, corrections, external changes, verification, unresolved items, and the next safe action.
+- Never put tokens, secret values, one-time codes, personal data, or private contents in code, logs,
+  issue comments, pull requests, or the journal.
+
+## Publish and continue
+
+1. Review the complete diff and confirm every acceptance box is demonstrably satisfied.
+2. Commit and push the issue branch.
+3. Open one pull request whose body contains `Closes #N`, the acceptance evidence, verification
+   results, and any human checks still needed.
+4. Do not mark criteria complete without evidence. Do not close the issue manually; the merge does it.
+5. Do not auto-merge by default. A user must explicitly authorize an auto-merge policy, and CI must
+   already protect the branch before an agent may use it.
+6. In **single-issue mode**, hand off the pull request and stop.
+7. In **runway mode**, once the branch is clean and pushed, return to synchronized `main`, rerun the
+   ready command, and take another available issue that does not depend on the unmerged work. Continue
+   until no available issue remains or a gate needs the user.
+
+## Stop gates
+
+Pause that issue and clearly tell the user what is needed when any of these occurs:
+
+- a browser login, external-service authorization, project creation, billing choice, or secret entry;
+- a destructive or irreversible operation that was not explicitly authorized;
+- acceptance criteria conflict with reality or require widening scope;
+- required access, professional content judgment, or product judgment is missing;
+- CI/review/merge is the only remaining action and no explicit auto-merge policy exists.
+
+When one issue hits a gate, runway mode may continue on a different available ready issue. Never route
+around a gate by weakening the acceptance criteria, inventing data, exposing a secret, or implementing
+a blocked dependent.
+
+See `docs/process/HUMAN_GATES.md` for known service and credential gates.

--- a/docs/process/HUMAN_GATES.md
+++ b/docs/process/HUMAN_GATES.md
@@ -1,0 +1,24 @@
+# Known human and service gates
+
+These are predictable pauses, not surprises or reasons to abandon the run. An agent should complete
+all safe local work first, then state the exact destination where Eric must authorize or enter a value.
+Secret values are never pasted into chat, committed, or echoed into logs.
+
+| Gate | Earliest issue | What the agent can do alone | What Eric may need to do |
+|---|---|---|---|
+| Vercel account/project | ENV-03 | Prepare deploy config and verify the local build | Authorize Vercel and confirm/link the project |
+| New Supabase project | DATA-01a | Write and locally verify migrations | Authorize Supabase and create/link the new project if CLI access is absent |
+| Old catalog export | DATA-02 | Reconstruct and audit the 140-row catalog committed in the archived repo | Grant old-project read access so the expected 173 live rows can be exported and reconciled |
+| Browser Supabase client | DATA-03 | Add typed client and environment validation | Put the project URL and public anon key in the requested local/hosting environment |
+| Privileged E2E lifecycle | ENV-07 | Build seed/reset and RLS tests | Store the service-role/test credential in the named secret store |
+| Anthropic generation | GEN-02b | Build prompt, schema validation, and function boundary | Store `ANTHROPIC_API_KEY` in Supabase Edge Function secrets |
+| Merge | every issue | Open a tested PR with evidence | Review and merge, unless an explicit protected auto-merge policy is later approved |
+
+## Secret destinations
+
+- Browser-safe Supabase URL and anon key: gitignored local environment plus Vercel environment values.
+- Supabase service-role/test credentials: CI or hosting secret storage only; never browser code.
+- Anthropic API key: Supabase Edge Function secret storage only.
+- GitHub, Supabase, and Vercel login tokens: their own CLI/keychain/browser authorization flows.
+
+The agent asks for the **action and destination**, never the secret value.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "dag:ready": "python3 scripts/dag-ready.py",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:dag": "python3 -m unittest discover -s scripts/tests -p 'test_*.py'",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/scripts/dag-ready.py
+++ b/scripts/dag-ready.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Report CLEAR's live, unclaimed GitHub DAG ready queue."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DAG = ROOT / "docs" / "DAG.md"
+ISSUE_ID = re.compile(r"\[([A-Z]+-[0-9]+[a-z]?)\]")
+
+
+class DagReadyError(RuntimeError):
+    """Raised when the live queue cannot be reported safely."""
+
+
+def gh_json(arguments: list[str]) -> Any:
+    try:
+        result = subprocess.run(
+            ["gh", *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise DagReadyError("GitHub CLI (`gh`) is not installed.") from error
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or error.stdout.strip() or "unknown GitHub CLI error"
+        raise DagReadyError(detail) from error
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise DagReadyError("GitHub returned data that was not valid JSON.") from error
+
+
+def resolve_repo(explicit_repo: str | None) -> str:
+    if explicit_repo:
+        return explicit_repo
+    result = gh_json(["repo", "view", "--json", "nameWithOwner"])
+    return str(result["nameWithOwner"])
+
+
+def split_repo(repo: str) -> tuple[str, str]:
+    parts = repo.split("/", maxsplit=1)
+    if len(parts) != 2 or not all(parts):
+        raise DagReadyError(f"Expected repository as owner/name, received: {repo}")
+    return parts[0], parts[1]
+
+
+def read_critical_ids(path: Path = DEFAULT_DAG) -> set[str]:
+    if not path.exists():
+        return set()
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"## Critical path\s+(.*?)(?=\n## )", text, re.DOTALL)
+    if not match:
+        return set()
+    return set(re.findall(r"\b[A-Z]+-[0-9]+[a-z]?\b", match.group(1)))
+
+
+def issue_id(title: str) -> str | None:
+    match = ISSUE_ID.search(title)
+    return match.group(1) if match else None
+
+
+def milestone_order(issue: dict[str, Any]) -> tuple[int, str]:
+    milestone = issue.get("milestone") or {}
+    title = str(milestone.get("title") or "")
+    match = re.fullmatch(r"M(\d+)", title)
+    return (int(match.group(1)), title) if match else (sys.maxsize, title)
+
+
+def open_dependency_index(graph_nodes: list[dict[str, Any]]) -> dict[int, dict[str, int]]:
+    index: dict[int, dict[str, int]] = {}
+    for node in graph_nodes:
+        blockers = node.get("blockedBy", {}).get("nodes", [])
+        dependents = node.get("blocking", {}).get("nodes", [])
+        index[int(node["number"])] = {
+            "open_blockers": sum(item.get("state") == "OPEN" for item in blockers),
+            "open_dependents": sum(item.get("state") == "OPEN" for item in dependents),
+        }
+    return index
+
+
+def closing_pr_index(pull_requests: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    index: dict[int, dict[str, Any]] = {}
+    for pull_request in pull_requests:
+        for issue in pull_request.get("closingIssuesReferences") or []:
+            index[int(issue["number"])] = {
+                "number": int(pull_request["number"]),
+                "url": pull_request["url"],
+                "head": pull_request["headRefName"],
+            }
+    return index
+
+
+def validate_ready_sets(native_numbers: set[int], graph_numbers: set[int]) -> None:
+    if native_numbers == graph_numbers:
+        return
+    only_native = sorted(native_numbers - graph_numbers)
+    only_graph = sorted(graph_numbers - native_numbers)
+    raise DagReadyError(
+        "GitHub readiness signals disagree; refusing to recommend work. "
+        f"Native-only: {only_native or 'none'}; open-blocker-only: {only_graph or 'none'}."
+    )
+
+
+def rank_ready(
+    native_ready: list[dict[str, Any]],
+    dependency_index: dict[int, dict[str, int]],
+    pull_request_index: dict[int, dict[str, Any]],
+    critical_ids: set[str],
+) -> list[dict[str, Any]]:
+    ranked: list[dict[str, Any]] = []
+    for issue in native_ready:
+        number = int(issue["number"])
+        dependency = dependency_index[number]
+        identifier = issue_id(str(issue["title"]))
+        ranked.append(
+            {
+                **issue,
+                "id": identifier,
+                "fanout": dependency["open_dependents"],
+                "critical": identifier in critical_ids,
+                "pullRequest": pull_request_index.get(number),
+            }
+        )
+
+    return sorted(
+        ranked,
+        key=lambda item: (
+            item["pullRequest"] is not None,
+            *milestone_order(item),
+            -int(item["fanout"]),
+            not bool(item["critical"]),
+            int(item["number"]),
+        ),
+    )
+
+
+def fetch_queue(repo: str) -> list[dict[str, Any]]:
+    native_ready = gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--search",
+            "is:open -is:blocked",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,url,milestone,labels",
+        ]
+    )
+
+    owner, name = split_repo(repo)
+    query = """
+      query($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          issues(first: 100, states: OPEN, orderBy: {field: CREATED_AT, direction: ASC}) {
+            nodes {
+              number
+              blockedBy(first: 100) { nodes { number state } }
+              blocking(first: 100) { nodes { number state } }
+            }
+            pageInfo { hasNextPage }
+          }
+        }
+      }
+    """
+    graph = gh_json(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+        ]
+    )
+    issues = graph["data"]["repository"]["issues"]
+    if issues["pageInfo"]["hasNextPage"]:
+        raise DagReadyError("The repository has more than 100 open issues; pagination is required.")
+
+    dependency_index = open_dependency_index(issues["nodes"])
+    graph_ready = {
+        number
+        for number, dependency in dependency_index.items()
+        if dependency["open_blockers"] == 0
+    }
+    native_numbers = {int(issue["number"]) for issue in native_ready}
+    validate_ready_sets(native_numbers, graph_ready)
+
+    pull_requests = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,url,headRefName,closingIssuesReferences",
+        ]
+    )
+    return rank_ready(
+        native_ready,
+        dependency_index,
+        closing_pr_index(pull_requests),
+        read_critical_ids(),
+    )
+
+
+def plain_report(repo: str, queue: list[dict[str, Any]]) -> str:
+    available = [issue for issue in queue if issue["pullRequest"] is None]
+    in_progress = [issue for issue in queue if issue["pullRequest"] is not None]
+    lines = [
+        f"CLEAR DAG ready queue — {repo}",
+        f"{len(queue)} ready · {len(available)} available · {len(in_progress)} in an open PR",
+        "",
+        "Rank  Issue  Milestone  Fan-out  Path      State       Title",
+    ]
+    for rank, issue in enumerate(queue, start=1):
+        milestone = (issue.get("milestone") or {}).get("title") or "—"
+        path = "critical" if issue["critical"] else "—"
+        state = f"PR #{issue['pullRequest']['number']}" if issue["pullRequest"] else "available"
+        lines.append(
+            f"{rank:<5} #{issue['number']:<5} {milestone:<10} {issue['fanout']:<8} "
+            f"{path:<9} {state:<11} {issue['title']}"
+        )
+    lines.append("")
+    if available:
+        recommendation = available[0]
+        lines.append(
+            f"Recommended: #{recommendation['number']} {recommendation['title']} "
+            f"({recommendation['fanout']} open dependents)"
+        )
+        lines.append(
+            f"Inspect: gh issue view {recommendation['number']} --repo {repo} --comments"
+        )
+    else:
+        lines.append("No unclaimed ready issue. Review or merge the open pull requests, then rerun.")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="GitHub repository as owner/name (defaults to current remote)")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_args()
+    try:
+        repo = resolve_repo(arguments.repo)
+        queue = fetch_queue(repo)
+    except (DagReadyError, KeyError, TypeError) as error:
+        print(f"dag-ready: {error}", file=sys.stderr)
+        return 1
+
+    if arguments.json:
+        print(json.dumps({"repo": repo, "ready": queue}, indent=2))
+    else:
+        print(plain_report(repo, queue))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_dag_ready.py
+++ b/scripts/tests/test_dag_ready.py
@@ -1,0 +1,64 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "dag-ready.py"
+SPEC = importlib.util.spec_from_file_location("dag_ready", SCRIPT)
+assert SPEC and SPEC.loader
+dag_ready = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(dag_ready)
+
+
+class DagReadyTests(unittest.TestCase):
+    def test_closed_blockers_do_not_prevent_readiness(self):
+        index = dag_ready.open_dependency_index(
+            [
+                {
+                    "number": 2,
+                    "blockedBy": {"nodes": [{"number": 1, "state": "CLOSED"}]},
+                    "blocking": {"nodes": [{"number": 5, "state": "OPEN"}]},
+                }
+            ]
+        )
+        self.assertEqual(index[2], {"open_blockers": 0, "open_dependents": 1})
+
+    def test_rank_prefers_available_then_milestone_then_fanout(self):
+        issues = [
+            {"number": 2, "title": "[ENV-02] CI", "milestone": {"title": "M0"}},
+            {"number": 3, "title": "[ENV-03] Deploy", "milestone": {"title": "M0"}},
+            {"number": 4, "title": "[ENV-04] Dev", "milestone": {"title": "M1"}},
+        ]
+        dependency_index = {
+            2: {"open_blockers": 0, "open_dependents": 2},
+            3: {"open_blockers": 0, "open_dependents": 5},
+            4: {"open_blockers": 0, "open_dependents": 9},
+        }
+        pull_requests = {3: {"number": 74, "url": "url", "head": "env-03"}}
+
+        ranked = dag_ready.rank_ready(
+            issues, dependency_index, pull_requests, {"ENV-02", "ENV-04"}
+        )
+
+        self.assertEqual([issue["number"] for issue in ranked], [2, 4, 3])
+
+    def test_native_and_open_blocker_sets_must_match(self):
+        with self.assertRaises(dag_ready.DagReadyError):
+            dag_ready.validate_ready_sets({2, 3}, {2})
+
+    def test_closing_issue_references_claim_ready_work(self):
+        index = dag_ready.closing_pr_index(
+            [
+                {
+                    "number": 72,
+                    "url": "https://example.test/pr/72",
+                    "headRefName": "env-01",
+                    "closingIssuesReferences": [{"number": 1}],
+                }
+            ]
+        )
+        self.assertEqual(index[1]["number"], 72)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Adds a deterministic, live-GitHub DAG runner plus one canonical agent loop shared by Claude Code and Codex.

## What changed

- `scripts/dag-ready.py` cross-checks GitHub's native ready search against dependency nodes with only open blockers counted
- ready work is ranked by milestone, open fan-out, then critical-path membership
- ready issues already tied to an open PR are marked in progress and not recommended again
- `docs/process/DAG_RUNNER.md` defines single-issue and runway modes
- `docs/process/HUMAN_GATES.md` identifies Supabase, Vercel, Anthropic-key, and merge pauses without exposing secrets
- project-local `clear-dag-runner` skills point Claude Code and Codex to the same canonical policy
- `docs/process/CATALOG_MIGRATION_SCOPE.md` records the catalog-only migration boundary and the verified 140-vs-173 source discrepancy
- root agent instructions, project map, playbook, package scripts, and process journal are updated

## Verification

- live private-repo check: 7 ready / 7 available; DS-01 correctly recommended with 10 open dependents
- runner unit tests: 4 passed
- graph baseline: 71 requirements / 136 edges
- ESLint: passed
- Vitest: 1 file / 2 tests passed
- TypeScript + Vite production build: passed (25 modules)
- `git diff --check`: passed

No product DAG node is implemented here, no secret values are introduced, and auto-merge remains disabled by default.

Closes #73
