### PR TITLE
[ENV-02] CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - name: Reject raw console usage
+        shell: bash
+        run: |
+          if grep -R -n -E \
+            --include='*.js' --include='*.jsx' --include='*.ts' --include='*.tsx' \
+            'console\.[[:alnum:]_$]+[[:space:]]*\(' src; then
+            echo 'Raw console.* usage is not allowed in src/' >&2
+            exit 1
+          fi
+      - name: Verify requirements graph
+        run: python3 scripts/gen-issues.py --check
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ Run `python3 scripts/dag-ready.py` instead of choosing from the issue list manua
 asks to run the DAG, automate the build, work unattended, or continue the rebuild, use the project
 skill `clear-dag-runner` and its canonical loop in `docs/process/DAG_RUNNER.md`.
 
+An approved ready issue authorizes routine implementation through a tested, pushed pull request.
+Do not repeatedly ask for permission to branch, edit, verify, commit, push, or open that PR.
+
 ## Process journal
 
 For every material work session, maintain `docs/journal/YYYY-MM-DD.md` at meaningful checkpoints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ ranks what remains. Take its recommendation unless Eric named another available 
 When Eric asks to run the DAG, automate the build, work unattended, or run for a while, use the
 project skill `clear-dag-runner`. Its canonical loop is `docs/process/DAG_RUNNER.md`.
 
+Selecting an approved ready issue authorizes its normal branch-to-PR implementation loop. Do not ask
+Eric to re-approve routine repository actions; pause only at the runner's explicit stop gates.
+
 **Never work an issue that is not in the ready queue.** If it looks ready but the queue
 disagrees, the graph is right — go read what it is blocked by.
 

--- a/PROJECT_MAP.md
+++ b/PROJECT_MAP.md
@@ -12,6 +12,7 @@ This is the honest ENV-01 scaffold. Update it only when a directory boundary or 
 | `src/test/` | Shared test setup | adding test-only configuration or helpers |
 | `docs/` | Frozen baseline and deep specs | recording product/design/process knowledge, not runtime code |
 | `scripts/` | Repository automation | adding a deterministic local or CI maintenance command |
+| `.github/workflows/` | GitHub pull-request automation | adding a required repository check or deployment workflow |
 | `.claude/skills/` | Claude Code project entry points | exposing a reusable workflow to Anthropic tooling |
 | `.agents/skills/` | Codex project entry points | exposing the same reusable workflow to Codex |
 

--- a/docs/journal/2026-08-29.md
+++ b/docs/journal/2026-08-29.md
@@ -166,3 +166,59 @@ longer unattended runs.
 - Next safe action: review and merge PR 74. Then synchronize `main`; invoking the
   `clear-dag-runner` skill in runway mode can begin the available product queue. Service-specific
   issues pause only at the documented human gates.
+
+## ENV-02 — CI and startup-friction retrospective
+
+### Intended outcome
+
+Start the first guarded product-work issue after the runner merged: add four visible pull-request
+checks for type safety, lint/policy, tests, and production build, then require them on `main`.
+
+### Why getting started felt clunky
+
+The setup was described in terms that collapsed distinct states. A repository existing locally was
+not the same as a coding agent running; a reusable agent instruction was called automation even
+though it launched nothing; and a ready GitHub issue was discussed as progress even though no agent
+had started implementing it. Repeated authentication, merge, and synchronization gates amplified
+that ambiguity. The result was technically traceable but experientially unclear.
+
+Future handoffs must state four facts in plain language: **what exists, what is running, what is
+blocked, and the one next action**. “Ready,” “configured,” and “automated” are not substitutes for
+those facts. Product progress and control-plane progress must be named separately.
+
+A second source of friction was unnecessary re-authorization. ENV-01 and ENV-02 already had approved,
+checkable acceptance criteria, but routine repository steps were repeatedly surfaced as though they
+were new product choices. The runner now treats selection of an approved ready issue as authorization
+for the complete reversible branch-to-PR loop. It pauses only for a real stop gate such as secrets,
+login, billing/privacy, destructive scope, requirement conflict, or merge policy.
+
+### External constraint discovered
+
+- ENV-02 is open and dependency-ready. Branch `env-02-ci` was created from synchronized `main`.
+- The current official releases are `actions/checkout` v7.0.1 and `actions/setup-node` v7.0.0; the
+  workflow uses their v7 release lines.
+- Reading `main` branch protection returned HTTP 403: GitHub requires an account-plan upgrade or a
+  public repository for this feature on the current private repo. No billing or privacy change was
+  made. The four checks can still be implemented and observed, but GitHub cannot enforce them as a
+  merge requirement until Eric chooses one of those options.
+
+### Implementation
+
+- Added four independently visible, five-minute-bounded PR jobs: Typecheck, Lint, Test, and Build.
+- Lint also rejects raw `console.*` calls under `src/` and validates the 71-node/136-edge requirement
+  graph, keeping the issue's policy checks inside the requested four-check surface.
+- Added a dedicated `typecheck` package command and documented the workflow boundary in the project
+  map.
+
+### Verification and next safe action
+
+- Initial clean local verification passed: typecheck; ESLint; raw-console scan; graph validation at
+  71 requirements/136 edges; Vitest at 1 file/2 tests; production build at 25 modules; four runner
+  unit tests; and `git diff --check`.
+- Controlled failure probes passed. A temporary number assigned to a string failed TypeScript with
+  TS2322; after removal, a temporary `console.log` failed the exact CI policy scan. Neither probe is
+  retained in the working tree.
+- Eric chose to make the repository public, removing GitHub's private-repository plan restriction.
+  Visibility was verified through GitHub before resuming. No billing change was made.
+- Live-PR verification is pending. The safe next action is to rerun the clean suite, push the branch,
+  confirm all four jobs on the PR, and then configure `main` to require them.

--- a/docs/journal/2026-08-29.md
+++ b/docs/journal/2026-08-29.md
@@ -220,5 +220,16 @@ login, billing/privacy, destructive scope, requirement conflict, or merge policy
   retained in the working tree.
 - Eric chose to make the repository public, removing GitHub's private-repository plan restriction.
   Visibility was verified through GitHub before resuming. No billing change was made.
-- Live-PR verification is pending. The safe next action is to rerun the clean suite, push the branch,
-  confirm all four jobs on the PR, and then configure `main` to require them.
+- Opened PR 75 with `Closes #2`. All four GitHub jobs passed: Build 11s, Lint 11s, Test 13s,
+  Typecheck 14s. This is comfortably inside the five-minute criterion.
+- GitHub also reported an existing Vercel preview deployment and preview-comment check as passing.
+  ENV-03 must audit this existing integration rather than assume deployment is wholly absent.
+- Enabled `main` branch protection with strict up-to-date status checks, required contexts Typecheck,
+  Lint, Test, and Build, and enforcement for administrators. Force pushes and branch deletion are
+  disabled; no approval-count rule was added because ENV-02 does not require one.
+- The initial protection write succeeded, but its output formatter expected context objects while
+  GitHub returned context-name strings, producing `expected an object but got: string`. A corrected
+  read verified the actual protection state; no second mutation or rollback was necessary.
+- Next safe action: push this final journal checkpoint, let the four checks rerun, and merge PR 75.
+  After the merge, synchronize `main` and start Claude Code on DS-01 in runway mode. Claude Code is
+  installed and instructed but is not currently running.

--- a/docs/process/DAG_RUNNER.md
+++ b/docs/process/DAG_RUNNER.md
@@ -3,6 +3,18 @@
 This is the canonical operating loop for a coding agent working CLEAR. Claude Code and Codex have
 thin project-local skills that point here so the behavior does not drift between tools.
 
+## Default autonomy
+
+Once Eric selects an approved, dependency-ready issue—or asks the runner to select one—the issue's
+acceptance criteria authorize the normal implementation loop. Proceed without asking again for each
+reversible step: create the branch, edit in scope, install locked dependencies, run checks, update the
+journal and issue, commit, push, and open the pull request. A tool may still display a platform
+permission prompt, but that is not a new product decision.
+
+Ask Eric only at a stop gate below. In particular, do not turn synchronization, ordinary GitHub
+reads/writes, or “which ready issue is next?” into repeated handoffs. Pull-request merge remains a
+review gate unless Eric establishes an explicit protected auto-merge policy.
+
 ## Start
 
 1. Read `CLAUDE.md` or `AGENTS.md`, `PROJECT_MAP.md`, and this document.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:dag": "python3 -m unittest discover -s scripts/tests -p 'test_*.py'",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "19.2.8",


### PR DESCRIPTION
## Outcome

Adds the four GitHub pull-request checks required by ENV-02 and tightens the agent loop so approved issues proceed through PR without repeated re-authorization.

## Checks

- **Typecheck** — `tsc --noEmit`
- **Lint** — ESLint, raw `console.*` rejection under `src/`, and the 71-node/136-edge requirements-graph check
- **Test** — Vitest
- **Build** — TypeScript plus the Vite production build

Each job uses the current v7 release line of the official checkout/setup-node actions, Node 24, locked installs, PR concurrency cancellation, read-only repository permissions, and a five-minute timeout.

## Verification

- Clean local suite passed: typecheck, lint, console policy, graph validation, tests, build, runner tests, and diff check
- Deliberate TypeScript probe failed with TS2322, then was removed
- Deliberate `console.log` probe failed the policy check, then was removed
- Public-repository visibility confirmed; no tracked environment files or common secret signatures found in repository history

After the four live checks appear, `main` will be configured to require Typecheck, Lint, Test, and Build before merge.

Closes #2
