### PR TITLE
[CORE-01] Error taxonomy + request IDs

### DIFF
--- a/docs/conventions/error-handling.md
+++ b/docs/conventions/error-handling.md
@@ -1,0 +1,100 @@
+# Error handling conventions
+
+This document defines CLEAR's error handling patterns. These conventions are enforced through
+code review and the typed error system in `src/state/errors.ts`.
+
+## The rule
+
+**Never throw string errors. Never catch and read `.message` directly.**
+
+```typescript
+// BAD: stringly-typed errors
+throw "User not found"
+throw new Error("Something went wrong")
+catch (e) { alert(e.message) }
+
+// GOOD: typed errors
+import { createError, ErrorCode, Result, err } from '@/state/errors'
+
+// Option 1: Return a Result
+function findUser(id: string): Result<User> {
+  if (!user) {
+    return err(createError(ErrorCode.PERSISTENCE_NOT_FOUND))
+  }
+  return ok(user)
+}
+
+// Option 2: Create and throw AppError (for unexpected cases)
+throw createError(ErrorCode.PERSISTENCE_NOT_FOUND, { requestId })
+```
+
+## Why
+
+1. **User-safe messages**: String errors leak implementation details. `AppError` messages are
+   written for users.
+2. **Correlation**: `requestId` connects client errors to edge function logs.
+3. **Type safety**: The compiler catches missing error handling.
+4. **Consistency**: Every error has a known structure for display.
+
+## Request ID format
+
+```
+req_<timestamp-base36>_<random-base36>
+```
+
+Example: `req_lxyz123_a1b2c3`
+
+- `req_` — visual prefix for logs
+- timestamp — milliseconds since epoch, base36 encoded
+- random — 6 random alphanumeric characters
+
+### Usage in edge functions
+
+```typescript
+// Client
+const requestId = generateRequestId()
+const response = await fetch('/api/generate', {
+  headers: { 'X-Request-ID': requestId }
+})
+if (!response.ok) {
+  return err(toAppError(await response.json(), ErrorCode.GENERATION_FAILED, requestId))
+}
+
+// Edge function
+const requestId = req.headers.get('X-Request-ID') || generateRequestId()
+// Use requestId in all logs
+// Return requestId in error responses
+```
+
+## Error categories
+
+| Prefix | When to use |
+|---|---|
+| `AUTH_*` | Authentication/authorization failures |
+| `NETWORK_*` | Connectivity and transport failures |
+| `VALIDATION_*` | Input validation failures |
+| `GENERATION_*` | Workout generation failures |
+| `PERSISTENCE_*` | Data storage failures |
+
+## Result vs throw
+
+Use `Result<T>` for **expected** failures:
+- User input validation
+- Not-found conditions
+- Business logic violations
+
+Use `throw createError()` for **unexpected** failures:
+- Programming errors
+- Invariant violations
+- Unrecoverable states
+
+## Review checklist
+
+When reviewing code that handles errors, check:
+
+- [ ] No `throw "string"` or `throw new Error("string")`
+- [ ] No `catch (e) { e.message }` without `toAppError()` wrapper
+- [ ] Edge function calls include `requestId`
+- [ ] Error boundaries use `toAppError()` to normalize
+- [ ] User-facing messages come from `getErrorMessage()`, not raw details
+- [ ] `Result<T>` used for expected failure modes

--- a/docs/journal/2026-08-29.md
+++ b/docs/journal/2026-08-29.md
@@ -233,3 +233,48 @@ login, billing/privacy, destructive scope, requirement conflict, or merge policy
 - Next safe action: push this final journal checkpoint, let the four checks rerun, and merge PR 75.
   After the merge, synchronize `main` and start Claude Code on DS-01 in runway mode. Claude Code is
   installed and instructed but is not currently running.
+
+## CORE-01 — Error taxonomy and request IDs
+
+### Intended outcome
+
+Create a typed error system that replaces stringly-typed errors. Every AppError carries a code,
+an optional requestId, and a user-safe message. Document the conventions and enforce via review.
+
+### Branch and issue
+
+Branch `core-01-error-taxonomy` from synchronized `main`. Issue #15. Started in runway mode while
+DS-01 (PR #76) awaits review — no dependency between them.
+
+### Implementation
+
+1. **Error codes**: Created `ErrorCode` enum with five categories: AUTH, NETWORK, VALIDATION,
+   GENERATION, PERSISTENCE. Each category has 4 specific codes.
+
+2. **AppError type**: Interface with `code`, `message`, `requestId?`, and `details?`. Created
+   `createError()` factory function that auto-populates the user-safe message from the code.
+
+3. **Request ID**: Format `req_<timestamp-base36>_<random-base36>`. Generator function returns
+   unique IDs. Documented in both the source file and the conventions doc.
+
+4. **Error messages**: 20 user-safe messages, one per error code. Factual and imperative, not
+   apologetic. Never expose internal details.
+
+5. **Result type**: Discriminated union `{ ok: true, value: T } | { ok: false, error: E }` with
+   `ok()`, `err()`, `isOk()`, `isErr()`, `unwrap()`, `unwrapOr()` helpers.
+
+6. **Type guards**: `isAppError()` and `toAppError()` for catching unknown errors at boundaries.
+
+7. **Convention doc**: `docs/conventions/error-handling.md` with the rule, examples, requestId
+   format, error categories, Result vs throw guidance, and review checklist.
+
+### Verification
+
+- `npm run typecheck`: passed
+- `npm run lint`: passed
+- `npm test`: 2 files, 28 tests passed (24 new tests for error system)
+- `npm run build`: passed (25 modules)
+
+### Next safe action
+
+Commit, push, and open PR with `Closes #15`. Continue runway mode with the next available issue.

--- a/src/state/errors.test.ts
+++ b/src/state/errors.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ErrorCode,
+  generateRequestId,
+  createError,
+  getErrorMessage,
+  ok,
+  err,
+  isOk,
+  isErr,
+  unwrap,
+  unwrapOr,
+  isAppError,
+  toAppError,
+} from './errors'
+
+describe('ErrorCode', () => {
+  it('has all expected categories', () => {
+    // Auth
+    expect(ErrorCode.AUTH_UNAUTHENTICATED).toBe('AUTH_UNAUTHENTICATED')
+    expect(ErrorCode.AUTH_SESSION_EXPIRED).toBe('AUTH_SESSION_EXPIRED')
+    expect(ErrorCode.AUTH_UNAUTHORIZED).toBe('AUTH_UNAUTHORIZED')
+    expect(ErrorCode.AUTH_INVALID_CREDENTIALS).toBe('AUTH_INVALID_CREDENTIALS')
+
+    // Network
+    expect(ErrorCode.NETWORK_OFFLINE).toBe('NETWORK_OFFLINE')
+    expect(ErrorCode.NETWORK_TIMEOUT).toBe('NETWORK_TIMEOUT')
+    expect(ErrorCode.NETWORK_SERVER_ERROR).toBe('NETWORK_SERVER_ERROR')
+    expect(ErrorCode.NETWORK_RATE_LIMITED).toBe('NETWORK_RATE_LIMITED')
+
+    // Validation
+    expect(ErrorCode.VALIDATION_REQUIRED_FIELD).toBe('VALIDATION_REQUIRED_FIELD')
+    expect(ErrorCode.VALIDATION_INVALID_FORMAT).toBe('VALIDATION_INVALID_FORMAT')
+    expect(ErrorCode.VALIDATION_OUT_OF_RANGE).toBe('VALIDATION_OUT_OF_RANGE')
+    expect(ErrorCode.VALIDATION_CONSTRAINT).toBe('VALIDATION_CONSTRAINT')
+
+    // Generation
+    expect(ErrorCode.GENERATION_FAILED).toBe('GENERATION_FAILED')
+    expect(ErrorCode.GENERATION_TIMEOUT).toBe('GENERATION_TIMEOUT')
+    expect(ErrorCode.GENERATION_INVALID_PARAMS).toBe('GENERATION_INVALID_PARAMS')
+    expect(ErrorCode.GENERATION_MODEL_ERROR).toBe('GENERATION_MODEL_ERROR')
+
+    // Persistence
+    expect(ErrorCode.PERSISTENCE_NOT_FOUND).toBe('PERSISTENCE_NOT_FOUND')
+    expect(ErrorCode.PERSISTENCE_CONFLICT).toBe('PERSISTENCE_CONFLICT')
+    expect(ErrorCode.PERSISTENCE_WRITE_FAILED).toBe('PERSISTENCE_WRITE_FAILED')
+    expect(ErrorCode.PERSISTENCE_READ_FAILED).toBe('PERSISTENCE_READ_FAILED')
+  })
+})
+
+describe('generateRequestId', () => {
+  it('generates IDs with correct format', () => {
+    const id = generateRequestId()
+    expect(id).toMatch(/^req_[a-z0-9]+_[a-z0-9]+$/)
+  })
+
+  it('generates unique IDs', () => {
+    const ids = new Set<string>()
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateRequestId())
+    }
+    expect(ids.size).toBe(100)
+  })
+})
+
+describe('createError', () => {
+  it('creates error with code and message', () => {
+    const error = createError(ErrorCode.AUTH_UNAUTHENTICATED)
+    expect(error.code).toBe(ErrorCode.AUTH_UNAUTHENTICATED)
+    expect(error.message).toBe('Sign in to continue.')
+    expect(error.requestId).toBeUndefined()
+    expect(error.details).toBeUndefined()
+  })
+
+  it('creates error with requestId', () => {
+    const requestId = generateRequestId()
+    const error = createError(ErrorCode.NETWORK_TIMEOUT, { requestId })
+    expect(error.requestId).toBe(requestId)
+  })
+
+  it('creates error with details', () => {
+    const error = createError(ErrorCode.VALIDATION_REQUIRED_FIELD, {
+      details: { field: 'email' },
+    })
+    expect(error.details).toEqual({ field: 'email' })
+  })
+})
+
+describe('getErrorMessage', () => {
+  it('returns user-safe messages for all error codes', () => {
+    // Every error code must have a non-empty message
+    const codes = Object.values(ErrorCode)
+    for (const code of codes) {
+      const message = getErrorMessage(code)
+      expect(message).toBeDefined()
+      expect(message.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('returns specific messages for each category', () => {
+    // Auth messages
+    expect(getErrorMessage(ErrorCode.AUTH_UNAUTHENTICATED)).toBe('Sign in to continue.')
+    expect(getErrorMessage(ErrorCode.AUTH_SESSION_EXPIRED)).toBe('Session expired. Sign in again.')
+    expect(getErrorMessage(ErrorCode.AUTH_UNAUTHORIZED)).toBe('Access denied.')
+    expect(getErrorMessage(ErrorCode.AUTH_INVALID_CREDENTIALS)).toBe('Invalid email or password.')
+
+    // Network messages
+    expect(getErrorMessage(ErrorCode.NETWORK_OFFLINE)).toBe('No connection. Check your network.')
+    expect(getErrorMessage(ErrorCode.NETWORK_TIMEOUT)).toBe('Request timed out. Try again.')
+    expect(getErrorMessage(ErrorCode.NETWORK_SERVER_ERROR)).toBe('Server error. Try again later.')
+    expect(getErrorMessage(ErrorCode.NETWORK_RATE_LIMITED)).toBe('Too many requests. Wait a moment.')
+
+    // Validation messages
+    expect(getErrorMessage(ErrorCode.VALIDATION_REQUIRED_FIELD)).toBe('Required field missing.')
+    expect(getErrorMessage(ErrorCode.VALIDATION_INVALID_FORMAT)).toBe('Invalid format.')
+    expect(getErrorMessage(ErrorCode.VALIDATION_OUT_OF_RANGE)).toBe('Value out of range.')
+    expect(getErrorMessage(ErrorCode.VALIDATION_CONSTRAINT)).toBe('Constraint violated.')
+
+    // Generation messages
+    expect(getErrorMessage(ErrorCode.GENERATION_FAILED)).toBe('Could not generate workout. Try again.')
+    expect(getErrorMessage(ErrorCode.GENERATION_TIMEOUT)).toBe('Generation took too long. Try simpler options.')
+    expect(getErrorMessage(ErrorCode.GENERATION_INVALID_PARAMS)).toBe('Invalid generation parameters.')
+    expect(getErrorMessage(ErrorCode.GENERATION_MODEL_ERROR)).toBe('Generation service error. Try again.')
+
+    // Persistence messages
+    expect(getErrorMessage(ErrorCode.PERSISTENCE_NOT_FOUND)).toBe('Not found.')
+    expect(getErrorMessage(ErrorCode.PERSISTENCE_CONFLICT)).toBe('Data conflict. Refresh and try again.')
+    expect(getErrorMessage(ErrorCode.PERSISTENCE_WRITE_FAILED)).toBe('Could not save. Try again.')
+    expect(getErrorMessage(ErrorCode.PERSISTENCE_READ_FAILED)).toBe('Could not load. Try again.')
+  })
+})
+
+describe('Result helpers', () => {
+  describe('ok', () => {
+    it('creates successful result', () => {
+      const result = ok(42)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.value).toBe(42)
+      }
+    })
+  })
+
+  describe('err', () => {
+    it('creates failed result', () => {
+      const error = createError(ErrorCode.NETWORK_OFFLINE)
+      const result = err(error)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toBe(error)
+      }
+    })
+  })
+
+  describe('isOk', () => {
+    it('returns true for successful results', () => {
+      expect(isOk(ok(42))).toBe(true)
+    })
+
+    it('returns false for failed results', () => {
+      expect(isOk(err(createError(ErrorCode.NETWORK_OFFLINE)))).toBe(false)
+    })
+  })
+
+  describe('isErr', () => {
+    it('returns true for failed results', () => {
+      expect(isErr(err(createError(ErrorCode.NETWORK_OFFLINE)))).toBe(true)
+    })
+
+    it('returns false for successful results', () => {
+      expect(isErr(ok(42))).toBe(false)
+    })
+  })
+
+  describe('unwrap', () => {
+    it('returns value for successful results', () => {
+      expect(unwrap(ok(42))).toBe(42)
+    })
+
+    it('throws for failed results', () => {
+      const error = createError(ErrorCode.NETWORK_OFFLINE)
+      expect(() => unwrap(err(error))).toThrow(error)
+    })
+  })
+
+  describe('unwrapOr', () => {
+    it('returns value for successful results', () => {
+      expect(unwrapOr(ok(42), 0)).toBe(42)
+    })
+
+    it('returns default for failed results', () => {
+      expect(unwrapOr(err(createError(ErrorCode.NETWORK_OFFLINE)), 0)).toBe(0)
+    })
+  })
+})
+
+describe('isAppError', () => {
+  it('returns true for AppError objects', () => {
+    const error = createError(ErrorCode.AUTH_UNAUTHENTICATED)
+    expect(isAppError(error)).toBe(true)
+  })
+
+  it('returns false for non-objects', () => {
+    expect(isAppError(null)).toBe(false)
+    expect(isAppError(undefined)).toBe(false)
+    expect(isAppError('string')).toBe(false)
+    expect(isAppError(42)).toBe(false)
+  })
+
+  it('returns false for objects without required fields', () => {
+    expect(isAppError({})).toBe(false)
+    expect(isAppError({ code: 'TEST' })).toBe(false)
+    expect(isAppError({ message: 'Test' })).toBe(false)
+  })
+})
+
+describe('toAppError', () => {
+  it('returns AppError unchanged', () => {
+    const error = createError(ErrorCode.AUTH_UNAUTHENTICATED)
+    expect(toAppError(error)).toBe(error)
+  })
+
+  it('attaches requestId to existing AppError', () => {
+    const error = createError(ErrorCode.AUTH_UNAUTHENTICATED)
+    const requestId = generateRequestId()
+    const result = toAppError(error, ErrorCode.NETWORK_SERVER_ERROR, requestId)
+    expect(result.code).toBe(ErrorCode.AUTH_UNAUTHENTICATED)
+    expect(result.requestId).toBe(requestId)
+  })
+
+  it('wraps Error instances', () => {
+    const error = new Error('Something went wrong')
+    const result = toAppError(error)
+    expect(result.code).toBe(ErrorCode.NETWORK_SERVER_ERROR)
+    expect(result.details).toEqual({ originalMessage: 'Something went wrong' })
+  })
+
+  it('wraps string errors', () => {
+    const result = toAppError('string error')
+    expect(result.code).toBe(ErrorCode.NETWORK_SERVER_ERROR)
+    expect(result.details).toEqual({ original: 'string error' })
+  })
+
+  it('uses custom fallback code', () => {
+    const result = toAppError('error', ErrorCode.PERSISTENCE_READ_FAILED)
+    expect(result.code).toBe(ErrorCode.PERSISTENCE_READ_FAILED)
+  })
+})

--- a/src/state/errors.ts
+++ b/src/state/errors.ts
@@ -1,0 +1,263 @@
+/**
+ * CLEAR Error Taxonomy
+ *
+ * A typed error union that replaces stringly-typed errors. Every AppError
+ * carries a code, an optional requestId (for edge function calls), and a
+ * user-safe message.
+ *
+ * Categories:
+ * - AUTH_*: Authentication and authorization failures
+ * - NETWORK_*: Connectivity and transport failures
+ * - VALIDATION_*: Input validation failures
+ * - GENERATION_*: Workout generation failures
+ * - PERSISTENCE_*: Data storage failures
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error Codes
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ErrorCode = {
+  // Auth errors
+  AUTH_UNAUTHENTICATED: 'AUTH_UNAUTHENTICATED',
+  AUTH_SESSION_EXPIRED: 'AUTH_SESSION_EXPIRED',
+  AUTH_UNAUTHORIZED: 'AUTH_UNAUTHORIZED',
+  AUTH_INVALID_CREDENTIALS: 'AUTH_INVALID_CREDENTIALS',
+
+  // Network errors
+  NETWORK_OFFLINE: 'NETWORK_OFFLINE',
+  NETWORK_TIMEOUT: 'NETWORK_TIMEOUT',
+  NETWORK_SERVER_ERROR: 'NETWORK_SERVER_ERROR',
+  NETWORK_RATE_LIMITED: 'NETWORK_RATE_LIMITED',
+
+  // Validation errors
+  VALIDATION_REQUIRED_FIELD: 'VALIDATION_REQUIRED_FIELD',
+  VALIDATION_INVALID_FORMAT: 'VALIDATION_INVALID_FORMAT',
+  VALIDATION_OUT_OF_RANGE: 'VALIDATION_OUT_OF_RANGE',
+  VALIDATION_CONSTRAINT: 'VALIDATION_CONSTRAINT',
+
+  // Generation errors
+  GENERATION_FAILED: 'GENERATION_FAILED',
+  GENERATION_TIMEOUT: 'GENERATION_TIMEOUT',
+  GENERATION_INVALID_PARAMS: 'GENERATION_INVALID_PARAMS',
+  GENERATION_MODEL_ERROR: 'GENERATION_MODEL_ERROR',
+
+  // Persistence errors
+  PERSISTENCE_NOT_FOUND: 'PERSISTENCE_NOT_FOUND',
+  PERSISTENCE_CONFLICT: 'PERSISTENCE_CONFLICT',
+  PERSISTENCE_WRITE_FAILED: 'PERSISTENCE_WRITE_FAILED',
+  PERSISTENCE_READ_FAILED: 'PERSISTENCE_READ_FAILED',
+} as const
+
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request ID
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Request ID format: `req_<timestamp-base36>_<random-base36>`
+ *
+ * Example: `req_lxyz123_a1b2c3`
+ *
+ * - Prefix `req_` for visual identification in logs
+ * - Timestamp portion: milliseconds since epoch, base36 encoded
+ * - Random portion: 6 random alphanumeric characters, base36 encoded
+ *
+ * The same ID is:
+ * 1. Generated client-side before calling an edge function
+ * 2. Sent to the edge function as a header or parameter
+ * 3. Returned by the edge function in the response
+ * 4. Attached to any error for correlation
+ */
+export function generateRequestId(): string {
+  const timestamp = Date.now().toString(36)
+  const random = Math.random().toString(36).slice(2, 8)
+  return `req_${timestamp}_${random}`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AppError Type
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The base error structure. All errors carry:
+ * - code: A typed error code from the ErrorCode enum
+ * - message: A user-safe message suitable for display
+ * - requestId: Optional correlation ID for edge function calls
+ * - details: Optional machine-readable details for debugging
+ */
+export interface AppError {
+  readonly code: ErrorCode
+  readonly message: string
+  readonly requestId?: string
+  readonly details?: Record<string, unknown>
+}
+
+/**
+ * Creates a typed AppError. Use this instead of `throw new Error("string")`.
+ */
+export function createError(
+  code: ErrorCode,
+  options?: {
+    requestId?: string
+    details?: Record<string, unknown>
+  }
+): AppError {
+  return {
+    code,
+    message: getErrorMessage(code),
+    requestId: options?.requestId,
+    details: options?.details,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error Messages
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Maps error codes to user-safe messages. These messages are:
+ * - Written in sentence case
+ * - Factual and imperative, not apologetic
+ * - Never expose internal details
+ */
+const errorMessages: Record<ErrorCode, string> = {
+  // Auth
+  [ErrorCode.AUTH_UNAUTHENTICATED]: 'Sign in to continue.',
+  [ErrorCode.AUTH_SESSION_EXPIRED]: 'Session expired. Sign in again.',
+  [ErrorCode.AUTH_UNAUTHORIZED]: 'Access denied.',
+  [ErrorCode.AUTH_INVALID_CREDENTIALS]: 'Invalid email or password.',
+
+  // Network
+  [ErrorCode.NETWORK_OFFLINE]: 'No connection. Check your network.',
+  [ErrorCode.NETWORK_TIMEOUT]: 'Request timed out. Try again.',
+  [ErrorCode.NETWORK_SERVER_ERROR]: 'Server error. Try again later.',
+  [ErrorCode.NETWORK_RATE_LIMITED]: 'Too many requests. Wait a moment.',
+
+  // Validation
+  [ErrorCode.VALIDATION_REQUIRED_FIELD]: 'Required field missing.',
+  [ErrorCode.VALIDATION_INVALID_FORMAT]: 'Invalid format.',
+  [ErrorCode.VALIDATION_OUT_OF_RANGE]: 'Value out of range.',
+  [ErrorCode.VALIDATION_CONSTRAINT]: 'Constraint violated.',
+
+  // Generation
+  [ErrorCode.GENERATION_FAILED]: 'Could not generate workout. Try again.',
+  [ErrorCode.GENERATION_TIMEOUT]:
+    'Generation took too long. Try simpler options.',
+  [ErrorCode.GENERATION_INVALID_PARAMS]: 'Invalid generation parameters.',
+  [ErrorCode.GENERATION_MODEL_ERROR]: 'Generation service error. Try again.',
+
+  // Persistence
+  [ErrorCode.PERSISTENCE_NOT_FOUND]: 'Not found.',
+  [ErrorCode.PERSISTENCE_CONFLICT]: 'Data conflict. Refresh and try again.',
+  [ErrorCode.PERSISTENCE_WRITE_FAILED]: 'Could not save. Try again.',
+  [ErrorCode.PERSISTENCE_READ_FAILED]: 'Could not load. Try again.',
+}
+
+/**
+ * Returns the user-safe message for an error code.
+ */
+export function getErrorMessage(code: ErrorCode): string {
+  return errorMessages[code]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Result Type
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A discriminated union for operation results. Use instead of try/catch
+ * for expected failure modes.
+ */
+export type Result<T, E = AppError> =
+  | { ok: true; value: T }
+  | { ok: false; error: E }
+
+/**
+ * Creates a successful result.
+ */
+export function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value }
+}
+
+/**
+ * Creates a failed result.
+ */
+export function err<E>(error: E): Result<never, E> {
+  return { ok: false, error }
+}
+
+/**
+ * Type guard for successful results.
+ */
+export function isOk<T, E>(result: Result<T, E>): result is { ok: true; value: T } {
+  return result.ok
+}
+
+/**
+ * Type guard for failed results.
+ */
+export function isErr<T, E>(result: Result<T, E>): result is { ok: false; error: E } {
+  return !result.ok
+}
+
+/**
+ * Unwraps a successful result or throws if failed.
+ * Use sparingly — prefer pattern matching on the result.
+ */
+export function unwrap<T, E>(result: Result<T, E>): T {
+  if (result.ok) {
+    return result.value
+  }
+  throw result.error
+}
+
+/**
+ * Unwraps a successful result or returns a default value.
+ */
+export function unwrapOr<T, E>(result: Result<T, E>, defaultValue: T): T {
+  return result.ok ? result.value : defaultValue
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type Guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Type guard to check if an unknown value is an AppError.
+ */
+export function isAppError(value: unknown): value is AppError {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'code' in value &&
+    'message' in value &&
+    typeof (value as AppError).code === 'string' &&
+    typeof (value as AppError).message === 'string'
+  )
+}
+
+/**
+ * Converts an unknown caught error to an AppError.
+ * Use this at catch boundaries to normalize errors.
+ */
+export function toAppError(
+  error: unknown,
+  fallbackCode: ErrorCode = ErrorCode.NETWORK_SERVER_ERROR,
+  requestId?: string
+): AppError {
+  if (isAppError(error)) {
+    // Already an AppError, optionally attach requestId
+    return requestId ? { ...error, requestId } : error
+  }
+
+  // Unknown error — wrap in fallback
+  return createError(fallbackCode, {
+    requestId,
+    details:
+      error instanceof Error
+        ? { originalMessage: error.message }
+        : { original: String(error) },
+  })
+}


### PR DESCRIPTION
## Summary

- Creates typed error system replacing stringly-typed errors
- Every `AppError` carries `code`, `requestId`, and user-safe `message`
- Request ID format: `req_<timestamp-base36>_<random-base36>`
- `Result<T,E>` discriminated union for expected failure modes
- Convention doc with review checklist

## Acceptance checklist

- [x] Every `AppError` carries `code`, `requestId` (where applicable), and a user-safe message
- [x] Unit tests cover the error→message mapping (24 new tests)
- [x] No `throw "string"` / `catch (e) { e.message }` patterns — enforced by convention doc + review checklist
- [x] `requestId` format documented; the same ID is sent to and returned by edge functions

## Implementation

| File | Purpose |
|---|---|
| `src/state/errors.ts` | Error codes, AppError type, Result helpers, type guards |
| `src/state/errors.test.ts` | 24 unit tests covering all error codes and helpers |
| `docs/conventions/error-handling.md` | Usage patterns, review checklist |

## Error categories

- `AUTH_*` — Authentication/authorization failures (4 codes)
- `NETWORK_*` — Connectivity and transport failures (4 codes)
- `VALIDATION_*` — Input validation failures (4 codes)
- `GENERATION_*` — Workout generation failures (4 codes)
- `PERSISTENCE_*` — Data storage failures (4 codes)

## Test plan

- [x] `npm run typecheck` — passed
- [x] `npm run lint` — passed
- [x] `npm test` — 2 files, 28 tests passed
- [x] `npm run build` — passed

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)